### PR TITLE
Fix the Picnic logo URL in the avatar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: picnic.tech
 description: A humble milkman standing on the shoulder of giants
 
-avatar: https://picnic.app/logo.png
+avatar: https://picnic.app/logo
 
 footer-links:
   email: 


### PR DESCRIPTION
Quick fix: the location for the picnic-web hosted Picnic logo has changed, resulting in a broken banner:
<img width="629" height="182" alt="image" src="https://github.com/user-attachments/assets/6ca65373-1641-4ce6-8851-af3ab4ce57ea" />

The closest I found is https://picnic.app/logo, I didn't investigate why the website doesn't support the redirection to the correct cloud front hosted image extensions ([png](https://d2jxuf8ovdiw8x.cloudfront.net/uploads/2020/09/logo.png), [svg](https://d2jxuf8ovdiw8x.cloudfront.net/uploads/2020/09/logo.svg)). Couldn't verify locally as the outdated Ruby gems in the build do not support being built on Apple Silicon.